### PR TITLE
drf-haystack-139

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'drf_haystack'
-copyright = '%d, Inonit AS' % date.today().year
+copyright = '%d, Rolf Håvard Blindheim' % date.today().year
 author = 'Rolf Håvard Blindheim'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -172,7 +172,7 @@ intersphinx_mapping = {
 
 # Configurations for extlinks
 extlinks = {
-    'drf-pr': ('https://github.com/inonit/drf-haystack/pull/%s', 'PR#'),
-    'drf-issue': ('https://github.com/inonit/drf-haystack/issues/%s', '#'),
+    'drf-pr': ('https://github.com/rhblind/drf-haystack/pull/%s', 'PR#'),
+    'drf-issue': ('https://github.com/rhblind/drf-haystack/issues/%s', '#'),
     'haystack-issue': ('https://github.com/django-haystack/django-haystack/issues/%s', '#')
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,10 +100,17 @@ This library has mainly been written by `me <https://github.com/rhblind>`_ while
 at `Inonit <https://github.com/inonit>`_. I have also had some help from these amazing people!
 Thanks guys!
 
-    - See the full list of `contributors <https://github.com/inonit/drf-haystack/graphs/contributors>`_.
+    - See the full list of `contributors <https://github.com/rhblind/drf-haystack/graphs/contributors>`_.
 
 Changelog
 =========
+
+v1.8.6
+------
+*Release date: Not released*
+
+    - Fixed :drf-issue:`139`. Overriding declared fields must now use ``serializers.SerializerMethodField()`` and are
+      handled by stock DRF. We don't need any custom functionality for this.
 
 v1.8.5
 ------
@@ -123,13 +130,13 @@ v1.8.3
 ------
 *Release date: 2018-06-16*
 
-    - Fixed issues with `__in=[...]` and `__range=[...]` filters. Closes :drf-issue:`128`.
+    - Fixed issues with ``__in=[...]`` and ``__range=[...]`` filters. Closes :drf-issue:`128`.
 
 v1.8.2
 ------
 *Release date: 2018-05-22*
 
-    - Fixed issue with `_get_count` for DRF v3.8
+    - Fixed issue with ``_get_count`` for DRF v3.8
 
 v1.8.1
 ------

--- a/drf_haystack/__init__.py
+++ b/drf_haystack/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 __title__ = "drf-haystack"
-__version__ = "1.8.5"
+__version__ = "1.8.6"
 __author__ = "Rolf Haavard Blindheim"
 __license__ = "MIT License"
 

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -227,12 +227,6 @@ class HaystackSerializer(six.with_metaclass(HaystackSerializerMeta, serializers.
             prefix_field_names = len(getattr(self.Meta, "index_classes")) > 1
             current_index = self._get_index_class_name(type(instance.searchindex))
             for field in self.fields.keys():
-                # handle declared field value methods on serializer
-                value_method = getattr(self, "get_{}".format(field), None)
-                if value_method and callable(value_method):
-                    ret[field] = value_method()
-
-                # now convert namespaced field names
                 orig_field = field
                 if prefix_field_names:
                     parts = field.split("__")

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -106,16 +106,16 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
         class Serializer1(HaystackSerializer):
 
             integer_field = serializers.IntegerField()
-            city = serializers.CharField()
+            city = serializers.SerializerMethodField()
 
             class Meta:
                 index_classes = [MockPersonIndex]
                 fields = ["text", "firstname", "lastname", "autocomplete"]
 
-            def get_integer_field(self, obj):
+            def get_integer_field(self, instance):
                 return 1
 
-            def get_city(self, obj):
+            def get_city(self, instance):
                 return "Declared overriding field"
 
         class Serializer2(HaystackSerializer):
@@ -204,6 +204,12 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
         self.assertTrue(dog.data["has_rabies"])
         self.assertFalse(iguana.data["has_rabies"])
 
+    def test_serializer_declared_field_overrides(self):
+        obj = SearchQuerySet().filter(lastname="Foreman")[0]
+        serializer = self.serializer1(instance=obj)
+
+        self.assertEqual(serializer.data['city'], "Declared overriding field")
+
 
 class HaystackSerializerAllFieldsTestCase(TestCase):
 
@@ -256,17 +262,17 @@ class HaystackSerializerMultipleIndexTestCase(WarningTestCaseMixin, TestCase):
             """
             Multiple index serializer with declared fields
             """
-            _MockPersonIndex__hair_color = serializers.CharField()
-            extra = serializers.IntegerField()
+            _MockPersonIndex__hair_color = serializers.SerializerMethodField()
+            extra = serializers.SerializerMethodField()
 
             class Meta:
                 index_classes = [MockPersonIndex, MockPetIndex]
                 exclude = ["firstname"]
 
-            def get__MockPersonIndex__hair_color(self):
+            def get__MockPersonIndex__hair_color(self, instance):
                 return "black"
 
-            def get_extra(self):
+            def get_extra(self, instance):
                 return 1
 
         class Serializer3(HaystackSerializer):


### PR DESCRIPTION
 - Fixed 139 - Serializers must now use `serializers.SerializerMethodField` for overriding fields.
 - Updated docs - Links to new repository owner