### PR TITLE
Add support for DjangoRestFramework 3.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ sudo: required
 dist: xenial
 language: python
 python:
-  - 2.7
   - 3.4
   - 3.5
   - 3.6
   - 3.7
-  - pypy2.7-6.0
   - pypy3.5-6.0
 
 cache:
@@ -73,33 +71,8 @@ env:
 
 matrix:
   allow_failures:
-    - python: pypy2.7-6.0
     - python: pypy3.5-6.0
   exclude:
-    - python: pypy2.7-6.0
-      env: DJANGO_VERSION=">=2.0,<2.1" ES_VERSION=">=1.0.0,<2.0.0"
-    - python: pypy2.7-6.0
-      env: DJANGO_VERSION=">=2.0,<2.1" ES_VERSION=">=2.0.0,<3.0.0"
-    - python: pypy2.7-6.0
-      env: DJANGO_VERSION=">=2.1,<2.2" ES_VERSION=">=1.0.0,<2.0.0"
-    - python: pypy2.7-6.0
-      env: DJANGO_VERSION=">=2.1,<2.2" ES_VERSION=">=2.0.0,<3.0.0"
-    - python: pypy2.7-6.0
-      env: DJANGO_VERSION=">=2.2,<2.3" ES_VERSION=">=1.0.0,<2.0.0"
-    - python: pypy2.7-6.0
-      env: DJANGO_VERSION=">=2.2,<2.3" ES_VERSION=">=2.0.0,<3.0.0"
-    - python: 2.7
-      env: DJANGO_VERSION=">=2.0,<2.1" ES_VERSION=">=1.0.0,<2.0.0"
-    - python: 2.7
-      env: DJANGO_VERSION=">=2.0,<2.1" ES_VERSION=">=2.0.0,<3.0.0"
-    - python: 2.7
-      env: DJANGO_VERSION=">=2.1,<2.2" ES_VERSION=">=1.0.0,<2.0.0"
-    - python: 2.7
-      env: DJANGO_VERSION=">=2.1,<2.2" ES_VERSION=">=2.0.0,<3.0.0"
-    - python: 2.7
-      env: DJANGO_VERSION=">=2.2,<2.3" ES_VERSION=">=1.0.0,<2.0.0"
-    - python: 2.7
-      env: DJANGO_VERSION=">=2.2,<2.3" ES_VERSION=">=2.0.0,<3.0.0"
     - python: 3.4
       env: DJANGO_VERSION=">=2.1,<2.2" ES_VERSION=">=1.0.0,<2.0.0"
     - python: 3.4

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 django = ">=1.11,<2.3"
 django-haystack = ">=2.8,<2.9"
-djangorestframework = ">=3.7.0,<3.10"
+djangorestframework = ">=3.7.0,<3.11"
 python-dateutil = "*"
 
 [dev-packages]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Fresh [documentation available](https://drf-haystack.readthedocs.io/en/latest/) 
 Supported versions
 ------------------
 
-- Python 2.7, 3.4 and above
+- Python 3.4 and above
 - Django 1.11 and 2.0-2.2
 - Haystack 2.8 and above
 - Django REST Framework 3.7 and above

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Features
 
 Supported Python and Django versions:
 
-    - Python 2.7+ and Python 3.4+
+    - Python 3.4+
     - `All supported versions of Django <https://www.djangoproject.com/download/#supported-versions>`_
 
 

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,7 +1,7 @@
 coverage
 django>=1.11,<2.3
 django-haystack>=2.8,<2.9
-djangorestframework>=3.7.0,<3.10
+djangorestframework>=3.7.0,<3.11
 elasticsearch>=2.0.0,<3.0.0
 nose
 sphinx

--- a/drf_haystack/mixins.py
+++ b/drf_haystack/mixins.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from drf_haystack.filters import HaystackFacetFilter
@@ -13,7 +13,7 @@ class MoreLikeThisMixin(object):
     Mixin class for supporting "more like this" on an API View.
     """
 
-    @detail_route(methods=["get"], url_path="more-like-this")
+    @action(detail=True, methods=["get"], url_path="more-like-this")
     def more_like_this(self, request, pk=None):
         """
         Sets up a detail route for ``more-like-this`` results.
@@ -43,7 +43,7 @@ class FacetMixin(object):
     facet_objects_serializer_class = None
     facet_query_params_text = 'selected_facets'
 
-    @list_route(methods=["get"], url_path="facets")
+    @action(detail=False, methods=["get"], url_path="facets")
     def facets(self, request):
         """
         Sets up a list route for ``faceted`` results.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Django>=1.11,<2.3",
-        "djangorestframework>=3.7,<3.10",
+        "djangorestframework>=3.7,<3.11",
         "django-haystack>=2.8,<2.9",
         "python-dateutil"
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,6 @@
 envlist =
     docs,
 
-    py27-django1.11-es1.x,
-    py27-django1.11-es2.x,
-
     py34-django1.11-es1.x,
     py34-django1.11-es2.x,
     py34-django2.0-es1.x,
@@ -85,7 +82,6 @@ deps =
 
 [testenv]
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -103,26 +99,6 @@ deps =
     sphinx-rtd-theme
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
-
-
-#
-# PyPy 2.7
-#
-[testenv:pypy2-django1.11-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:pypy2-django1.11-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
 
 
 #
@@ -190,26 +166,6 @@ setenv =
 deps =
     {[es2.x]deps}
     {[django2.2]deps}
-    {[base]deps}
-
-
-#
-# CPython2.7
-#
-[testenv:py27-django1.11-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:py27-django1.11-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django1.11]deps}
     {[base]deps}
 
 


### PR DESCRIPTION
Support the latest version of DRF (3.10.x)

DjangoRestFramework dropped Python2 support in 3.10.0 (https://www.django-rest-framework.org/community/release-notes/#3100).

Since Python2 end of life is January  2020, I've also removed all references to Python2.7.
