### PR TITLE
Handle case where data to be highlighted is None, and minor refactoring

### DIFF
--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -470,9 +470,16 @@ class HighlighterMixin(object):
             if field.document is True:
                 return name
 
+    def get_terms(self, data):
+        """
+        Returns the terms to be highlighted
+        """
+        terms = " ".join(six.itervalues(self.context["request"].GET))
+        return terms
+
     def to_representation(self, instance):
         ret = super(HighlighterMixin, self).to_representation(instance)
-        terms = " ".join(six.itervalues(self.context["request"].GET))
+        terms = self.get_terms(ret)
         if terms:
             highlighter = self.get_highlighter()(terms, **{
                 "html_tag": self.highlighter_html_tag,

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -481,5 +481,7 @@ class HighlighterMixin(object):
             })
             document_field = self.get_document_field(instance)
             if highlighter and document_field:
-                ret["highlighted"] = highlighter.highlight(getattr(instance, self.highlighter_field or document_field))
+                # Handle case where this data is None, but highlight expects it to be a string
+                data_to_highlight = getattr(instance, self.highlighter_field or document_field) or ''
+                ret["highlighted"] = highlighter.highlight(data_to_highlight)
         return ret


### PR DESCRIPTION
1.  Handle case where data of the field to be highlighted is None,
 causing highlight method to fail since it expects data to be of string type. Fixes #155 

2. Taking out the extraction of terms from the request into a method of its own,
namely `get_terms` so that its easier to override it with a custom implementation,
adds to separation of concerns.