### PR TITLE
Support DRF 3.12.x

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,6 +105,13 @@ Thanks guys!
 Changelog
 =========
 
+v1.8.8
+------
+*Release date: 2020-09-28*
+
+    - Updated supported DRF versions
+
+
 v1.8.7
 ------
 *Release date: 2020-08-01*

--- a/drf_haystack/__init__.py
+++ b/drf_haystack/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 __title__ = "drf-haystack"
-__version__ = "1.8.7"
+__version__ = "1.8.8"
 __author__ = "Rolf Haavard Blindheim"
 __license__ = "MIT License"
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Django>=2.2,<3.1",
-        "djangorestframework>=3.7,<3.12",
+        "djangorestframework>=3.7,<3.13",
         "django-haystack>=2.8,<3.1",
         "python-dateutil"
     ],


### PR DESCRIPTION
The code was already 99% compatible with DRF 3.12.x since the Pipfile  support DRF `">=3.7.0,<3.13"` 
However, djangorestframework version support wasn't changed in the setup.py file

![image](https://user-images.githubusercontent.com/3911112/94465342-c27e3680-018d-11eb-9710-54a4f60ca136.png)
