### PR TITLE
Add 'default_same_param_operator' to the FilterQueryBackend

### DIFF
--- a/drf_haystack/filters.py
+++ b/drf_haystack/filters.py
@@ -94,6 +94,7 @@ class HaystackFilter(BaseHaystackFilterBackend):
 
     query_builder_class = FilterQueryBuilder
     default_operator = operator.and_
+    default_same_param_operator = operator.or_
 
 
 class HaystackAutocompleteFilter(HaystackFilter):


### PR DESCRIPTION
Also rename field_queries to param_queries to prevent confusion (filtering is done per param, not per field perse).

Fixes #92