### PR TITLE
Support Django-Haystack 3.1.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 django = ">=2.2,<3.3"
-django-haystack = ">=2.8,<=3.1"
+django-haystack = ">=2.8,<=3.2"
 djangorestframework = ">=3.7.0,<3.13"
 python-dateutil = "*"
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,6 +105,13 @@ Thanks guys!
 Changelog
 =========
 
+v1.8.11
+------
+*Release date: 2021-08-27*
+
+    - Updated supported Django-Haystack versions
+
+
 v1.8.10
 ------
 *Release date: 2021-04-12*

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,6 +1,6 @@
 coverage
 django>=2.2,<3.1
-django-haystack>=2.8,<3.1
+django-haystack>=2.8,<3.2
 djangorestframework>=3.7.0,<3.13
 elasticsearch>=2.0.0,<3.0.0
 nose

--- a/drf_haystack/__init__.py
+++ b/drf_haystack/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 __title__ = "drf-haystack"
-__version__ = "1.8.10"
+__version__ = "1.8.11"
 __author__ = "Rolf Haavard Blindheim"
 __license__ = "MIT License"
 

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -17,7 +17,7 @@ from django.core.exceptions import ImproperlyConfigured, FieldDoesNotExist
 
 from haystack import fields as haystack_fields
 from haystack.query import EmptySearchQuerySet
-from haystack.utils import Highlighter
+from haystack.utils.highlighting import Highlighter
 
 from rest_framework import serializers
 from rest_framework.fields import empty

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         "Django>=2.2,<3.3",
         "djangorestframework>=3.7,<3.13",
-        "django-haystack>=2.8,<3.1",
+        "django-haystack>=2.8,<3.2",
         "python-dateutil"
     ],
     tests_require=[


### PR DESCRIPTION
Support Django-Haystack 3.1.0

During their last deployment/release, the Django-Haystack has messed up their 3.0 version by overriding their wheel file with the 3.1.0 content.

By supporting django-haystack 3.1.0 ... there's no need to ask them to fix this annoying issue ( drf-haystack 1.8.10 is not compatible with django-haystack 3.1.0 )

![2021-08-27 at 12 07 PM](https://user-images.githubusercontent.com/3911112/131156736-b26907f8-546c-4720-9a01-6078ae634aa3.png)
![2021-08-27 at 12 08 PM](https://user-images.githubusercontent.com/3911112/131156813-aefed442-715a-4196-ab8b-ac928b587016.png)
