### PR TITLE
Update dosc declared fields

### DIFF
--- a/docs/09_multiple_indexes.rst
+++ b/docs/09_multiple_indexes.rst
@@ -82,17 +82,17 @@ The following example illustrates this usage:
 .. code-block:: python
 
     class AggregateSerializer(HaystackSerializer):
-        extra = serializers.CharField()
-        _ThingIndex__number = serializers.IntegerField()
+        extra = serializers.SerializerMethodField()
+        _ThingIndex__number = serializers.SerializerMethodField()
 
         class Meta:
             index_classes = [PersonIndex, PlaceIndex, ThingIndex]
             fields = ["firstname", "lastname", "address", "name"]
 
-        def get_extra(self):
+        def get_extra(self,instance):
             return "whatever"
 
-        def get__ThingIndex__number(self):
+        def get__ThingIndex__number(self,instance):
             return 42
 
 The results of a search might then look like the following:


### PR DESCRIPTION
According to v1.8.6 and #139 fields should be changed from serializers.IntegerField()/CharField()... to SerializerMethodField(). Also in get__<...> functions should be added instance arg couse of the DRF documentation.

I just read documentation without looking at the Chanel log and maybe if hadn't looked at the Chanel log after I would spend much more time searching what's wrong.
Please merge this request to avoid similar situations in the future. :+1: 