### PR TITLE
Return an empty query object instead of an empty list when no filter is passed

### DIFF
--- a/drf_haystack/query.py
+++ b/drf_haystack/query.py
@@ -155,10 +155,10 @@ class FilterQueryBuilder(BaseQueryBuilder):
                     applicable_filters.append(term)
 
         applicable_filters = six.moves.reduce(
-            self.default_operator, filter(lambda x: x, applicable_filters)) if applicable_filters else []
+            self.default_operator, filter(lambda x: x, applicable_filters)) if applicable_filters else self.view.query_object()
 
         applicable_exclusions = six.moves.reduce(
-            self.default_operator, filter(lambda x: x, applicable_exclusions)) if applicable_exclusions else []
+            self.default_operator, filter(lambda x: x, applicable_exclusions)) if applicable_exclusions else self.view.query_object()
 
         return applicable_filters, applicable_exclusions
 


### PR DESCRIPTION
`applicable_filters` and `applicable_exclusions` are of type `type(self.view.query_object)`. For  better consistency, we should return an empty query object instead of an empty list.