### PR TITLE
Add a GitHub Action to run tox

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,6 +15,7 @@ jobs:
           # cache: 'pip'  # Only use if there are requirements.txt files
       - run: pip install --upgrade pip
       - run: pip install setuptools tox
+      - run: pip install --editable .
       - run: tox -e ${{ matrix.job }}
 
   tox:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: 3.x
           # cache: 'pip'  # Only use if there are requirements.txt files
       - run: pip install --upgrade pip
-      - run: pip install tox
+      - run: pip install setuptools tox
       - run: tox -e ${{ matrix.job }}
 
   tox:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,45 @@
+name: tox
+on: [push, pull_request]
+jobs:
+  tox-jobs:
+    strategy:
+      fail-fast: false
+      matrix:
+        job: [docs]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          # cache: 'pip'  # Only use if there are requirements.txt files
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e ${{ matrix.job }}
+
+  tox:
+    strategy:
+      fail-fast: false
+      # max-parallel: 4
+      matrix:  # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
+        django-version: ['3.2', '4.2', '5.0']
+        elasticsearch-version: ['7.17.9']  # https://pypi.org/project/elasticsearch7
+        exclude:
+          - python-version: '3.8'
+            django-version: '5.0'
+          - python-version: '3.9'
+            django-version: '5.0'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          # cache: 'pip'  # Only use if there are requirements.txt files
+      - run: python3 --version && python --version
+      - run: pip install --upgrade pip
+      # - run: pip install django==${{ matrix.django-version }} elasticsearch==${{ matrix.elasticsearch-version }} tox
+      - run: pip install tox
+      - run: tox -e "py${{ matrix.python-version }}-django${{ matrix.django-version }}-es7.x"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,6 @@ jobs:
           # cache: 'pip'  # Only use if there are requirements.txt files
       - run: pip install --upgrade pip
       - run: pip install tox
-      - run: pip install --editable .
       - run: tox -e ${{ matrix.job }}
 
   tox:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,6 +15,7 @@ jobs:
           # cache: 'pip'  # Only use if there are requirements.txt files
       - run: pip install --upgrade pip
       - run: pip install tox
+      - run: pip install --editable .
       - run: tox -e ${{ matrix.job }}
 
   tox:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,7 +165,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    '': ('[http://docs.python.org/](http://docs.python.org//)', None),
+    'python': ('https://docs.python.org/3', None),
     'django': ('https://django.readthedocs.io/en/latest/', None),
     'haystack': ('https://django-haystack.readthedocs.io/en/latest/', None)
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ version = release = get_version(os.path.join('..', 'drf_haystack'))
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,7 +165,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'http://docs.python.org/': None,
+    '': ('[http://docs.python.org/](http://docs.python.org//)', None),
     'django': ('https://django.readthedocs.io/en/latest/', None),
     'haystack': ('https://django-haystack.readthedocs.io/en/latest/', None)
 }

--- a/tox.ini
+++ b/tox.ini
@@ -2,96 +2,66 @@
 envlist =
     docs,
 
-    pypy3-django2.2-es1.x,
-    pypy3-django2.2-es2.x,
+    pypy3-django3.2-es7.x,
+    pypy3-django4.2-es7.x,
+    pypy3-django5.0-es7.x,
 
-    py36-django2.2-es1.x,
-    py36-django2.2-es2.x,
-    py36-django3.0-es1.x,
-    py36-django3.0-es2.x,
-    py36-django3.1-es1.x,
-    py36-django3.1-es2.x,
-    py36-django3.2-es1.x,
-    py36-django3.2-es2.x,
+    py38-django3.2-es7.x,
+    py38-django4.2-es7.x,
+    py38-django5.0-es7.x,
 
-    py37-django2.2-es1.x,
-    py37-django2.2-es2.x,
-    py37-django3.0-es1.x,
-    py37-django3.0-es2.x,
-    py37-django3.1-es1.x,
-    py37-django3.1-es2.x,
-    py37-django3.2-es1.x,
-    py37-django3.2-es2.x,
+    py39-django3.2-es7.x,
+    py39-django4.2-es7.x,
+    py39-django5.0-es7.x,
 
-    py38-django2.2-es1.x,
-    py38-django2.2-es2.x,
-    py38-django3.0-es1.x,
-    py38-django3.0-es2.x,
-    py38-django3.1-es1.x,
-    py38-django3.1-es2.x,
-    py38-django3.2-es1.x,
-    py38-django3.2-es2.x,
-    py38-django4.1-es1.x,
-    py38-django4.1-es2.x,
+    py310-django3.2-es7.x,
+    py310-django4.2-es7.x,
+    py310-django5.0-es7.x,
 
+    py311-django3.2-es7.x,
+    py311-django4.2-es7.x,
+    py311-django5.0-es7.x,
 
-    py39-django2.2-es1.x,
-    py39-django2.2-es2.x,
-    py39-django3.0-es1.x,
-    py39-django3.0-es2.x,
-    py39-django3.1-es1.x,
-    py39-django3.1-es2.x,
-    py39-django3.2-es1.x,
-    py39-django3.2-es2.x,
-    py39-django4.1-es1.x,
-    py39-django4.1-es2.x,
+    py312-django3.2-es7.x,
+    py312-django4.2-es7.x,
+    py312-django5.0-es7.x,
 
 [base]
 deps =
     geopy
 
 
-[django2.2]
-deps =
-    Django>=2.2,<=2.3
-
-[django3.0]
-deps =
-    Django>=3.0,<3.1
-
-[django3.1]
-deps =
-    Django>=3.1,<3.2
-
 [django3.2]
 deps =
     Django>=3.2,<3.3
+
 [django4.2]
 deps =
-    Django>=4.0,<=4.2
+    Django>=4.2,<4.3
 
-[es1.x]
-setenv = VERSION_ES=>=1.0.0,<2.0.0 ELASTICSEARCH_URL=http://localhost:9200/
+[django5.0]
 deps =
-    elasticsearch>=1.0.0,<2.0.0
+    Django>=5.0,<5.1
 
-[es2.x]
-setenv = VERSION_ES=>=2.0.0,<3.0.0 ELASTICSEARCH_URL=http://localhost:9201/
+
+[es7.x]
+setenv = VERSION_ES=>=7.17.9,<8.0.0 ELASTICSEARCH_URL=http://localhost:9200/
 deps =
-    elasticsearch>=2.0.0,<3.0.0
+    elasticsearch>=7.17.9,<8.0.0
 
 
 [testenv]
 basepython =
-    py36: python3.6
-    py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
+    py311: python3.11
+    py312: python3.12
     pypy3: pypy3
 
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+# passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =
-    python {toxinidir}/setup.py test
+    python {toxinidir}/setup.py test  # This is deprecated!
 
 [testenv:docs]
 changedir = docs
@@ -102,326 +72,154 @@ commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 #
-# PyPy 3.6
+# PyPy 3.10
 #
 
-[testenv:pypy3-django2.2-es1.x]
+[testenv:pypy3-django3.2-es7.x]
 setenv =
-    {[es1.x]setenv}
+    {[es7.x]setenv}
 deps =
-    {[es1.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:pypy3-django2.2-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-#
-# CPython3.6
-#
-
-[testenv:py36-django2.2-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py36-django2.2-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py36-django3.0-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py36-django3.0-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py36-django3.1-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py36-django3.1-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py36-django3.2-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
+    {[es7.x]deps}
     {[django3.2]deps}
     {[base]deps}
 
-[testenv:py36-django3.2-es2.x]
+[testenv:pypy3-django4.2-es7.x]
 setenv =
-    {[es2.x]setenv}
+    {[es7.x]setenv}
 deps =
-    {[es2.x]deps}
-    {[django3.2]deps}
+    {[es7.x]deps}
+    {[django4.2]deps}
     {[base]deps}
 
-#
-# CPython3.7
-#
-
-[testenv:py37-django2.2-es1.x]
+[testenv:pypy3-django5.0-es7.x]
 setenv =
-    {[es1.x]setenv}
+    {[es7.x]setenv}
 deps =
-    {[es1.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py37-django2.2-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py37-django3.0-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py37-django3.0-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py37-django3.1-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py37-django3.1-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py37-django3.2-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.2]deps}
-    {[base]deps}
-
-[testenv:py37-django3.2-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.2]deps}
+    {[es7.x]deps}
+    {[django5.0]deps}
     {[base]deps}
 
 #
 # CPython3.8
 #
 
-[testenv:py38-django2.2-es1.x]
+[testenv:py38-django3.2-es7.x]
 setenv =
-    {[es1.x]setenv}
+    {[es7.x]setenv}
 deps =
-    {[es1.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py38-django2.2-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py38-django3.0-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py38-django3.0-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py38-django3.1-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py38-django3.1-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py38-django3.2-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
+    {[es7.x]deps}
     {[django3.2]deps}
     {[base]deps}
 
-[testenv:py38-django3.2-es2.x]
+[testenv:py38-django4.2-es7.x]
 setenv =
-    {[es2.x]setenv}
+    {[es7.x]setenv}
 deps =
-    {[es2.x]deps}
-    {[django3.2]deps}
+    {[es7.x]deps}
+    {[django4.2]deps}
     {[base]deps}
-[testenv:py38-django4.1-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django4.1]deps}
-    {[base]deps}
-
-[testenv:py38-django4.1-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django4.1]deps}
-    {[base]deps}
-
-
 
 #
 # CPython3.9
 #
 
-[testenv:py39-django2.2-es1.x]
+[testenv:py39-django3.2-es7.x]
 setenv =
-    {[es1.x]setenv}
+    {[es7.x]setenv}
 deps =
-    {[es1.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py39-django2.2-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py39-django3.0-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py39-django3.0-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py39-django3.1-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py39-django3.1-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py39-django3.2-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
+    {[es7.x]deps}
     {[django3.2]deps}
     {[base]deps}
 
-[testenv:py39-django3.2-es2.x]
+[testenv:py39-django4.2-es7.x]
 setenv =
-    {[es2.x]setenv}
+    {[es7.x]setenv}
 deps =
-    {[es2.x]deps}
-    {[django3.2]deps}
-    {[base]deps}
-[testenv:py39-django4.1-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django4.1]deps}
+    {[es7.x]deps}
+    {[django4.2]deps}
     {[base]deps}
 
-[testenv:py39-django4.1-es2.x]
+#
+# CPython3.10
+#
+
+[testenv:py310-django3.2-es7.x]
 setenv =
-    {[es2.x]setenv}
+    {[es7.x]setenv}
 deps =
-    {[es2.x]deps}
-    {[django4.1]deps}
+    {[es7.x]deps}
+    {[django3.2]deps}
+    {[base]deps}
+
+[testenv:py310-django4.2-es7.x]
+setenv =
+    {[es7.x]setenv}
+deps =
+    {[es7.x]deps}
+    {[django4.2]deps}
+    {[base]deps}
+
+[testenv:py310-django5.0-es7.x]
+setenv =
+    {[es7.x]setenv}
+deps =
+    {[es7.x]deps}
+    {[django5.0]deps}
+    {[base]deps}
+
+#
+# CPython3.11
+#
+
+[testenv:py311-django3.2-es7.x]
+setenv =
+    {[es7.x]setenv}
+deps =
+    {[es7.x]deps}
+    {[django3.2]deps}
+    {[base]deps}
+
+[testenv:py311-django4.2-es7.x]
+setenv =
+    {[es7.x]setenv}
+deps =
+    {[es7.x]deps}
+    {[django4.2]deps}
+    {[base]deps}
+
+[testenv:py311-django5.0-es7.x]
+setenv =
+    {[es7.x]setenv}
+deps =
+    {[es7.x]deps}
+    {[django5.0]deps}
+    {[base]deps}
+
+#
+# CPython3.12
+#
+
+[testenv:py312-django3.2-es7.x]
+setenv =
+    {[es7.x]setenv}
+deps =
+    {[es7.x]deps}
+    {[django3.2]deps}
+    {[base]deps}
+
+[testenv:py312-django4.2-es7.x]
+setenv =
+    {[es7.x]setenv}
+deps =
+    {[es7.x]deps}
+    {[django4.2]deps}
+    {[base]deps}
+
+[testenv:py312-django5.0-es7.x]
+setenv =
+    {[es7.x]setenv}
+deps =
+    {[es7.x]deps}
+    {[django5.0]deps}
     {[base]deps}
 


### PR DESCRIPTION
Test results: https://github.com/cclauss/drf-haystack/actions

`docs`
> FIXED. ~Warning, treated as error:
Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).~

> FIXED. ~Warning, treated as error:
Failed to read intersphinx_mapping[http://docs.python.org/], ignored: SphinxWarning('The pre-Sphinx 1.0 \'intersphinx_mapping\' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {\'<name>\': (\'[http://docs.python.org/\](http://docs.python.org//)', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping')~

> Warning, treated as error:
autodoc: failed to import module 'filters' from module 'drf_haystack'; the following exception was raised:
No module named 'pkg_resources'

`py3.8-django3.2-es7.x`
> django.core.exceptions.ImproperlyConfigured: The default alias 'default' must be included in the HAYSTACK_CONNECTIONS setting.
